### PR TITLE
fix: trash dates are messed up by std::mktime() when time values are not initialized

### DIFF
--- a/modules/eventsview.cpp
+++ b/modules/eventsview.cpp
@@ -167,7 +167,7 @@ void eventsview::render()
 		auto const tm = *std::localtime(&ev.start);
 		auto const duration = std::difftime(ev.end, ev.start);
 		char buffer[256];
-		snprintf(buffer, sizeof buffer, "%02d.%02d.%04d %02d:%02d", tm.tm_mday, tm.tm_mon, tm.tm_year, tm.tm_hour, tm.tm_min);
+		snprintf(buffer, sizeof buffer, "%02d.%02d.%04d %02d:%02d", tm.tm_mday, tm.tm_mon, 1900+tm.tm_year, tm.tm_hour, tm.tm_min);
 
 		std::string duration_text;
 		if(duration < 3600)

--- a/modules/infoview.cpp
+++ b/modules/infoview.cpp
@@ -35,6 +35,12 @@ namespace
 			auto const json = nlohmann::json::parse(raw->begin(), raw->end());
 
 			Muell muell;
+
+			// initializing time values to prevent std::mktime() from chaotically changing the date
+		 	muell.date.tm_sec = 0;
+			muell.date.tm_min = 0;
+			muell.date.tm_hour = 0;
+
 			std::stringstream str { std::string(json["date"]) };
 			str >> std::get_time(&muell.date, "%Y-%m-%d");
 			muell.mail_sended = json["mail_sended"];


### PR DESCRIPTION
see http://www.cplusplus.com/reference/ctime/mktime/

"A call to this function automatically adjusts the values of the members of timeptr if they are off-range or -in the case of tm_wday and tm_yday- if they have values that do not match the date described by the other members."
